### PR TITLE
Make some scripts executable

### DIFF
--- a/services/wesher/Dockerfile
+++ b/services/wesher/Dockerfile
@@ -7,4 +7,5 @@ RUN chmod a+x wesher
 COPY run.sh run.sh
 COPY hosts_updated.sh .
 COPY watch_hosts.sh .
+RUN chmod a+x wesher run.sh hosts_updated.sh watch_hosts.sh
 CMD [ "/run.sh" ]

--- a/services/wireguard/Dockerfile
+++ b/services/wireguard/Dockerfile
@@ -49,5 +49,6 @@ RUN install_packages kmod wget wireguard-tools dnsutils qrencode miniupnpc
 COPY run.sh /run.sh
 COPY install.sh /install.sh
 
+RUN chmod u+x /install.sh /run.sh
 ENTRYPOINT [ "/install.sh" ]
 CMD [ "/run.sh" ]


### PR DESCRIPTION
The wireguard and wesher containers were trying to execute scripts that were non-executable. This would lead to the container restarting endlessly. Alternatively, this can be fixed by invoking the scripts with bash.