### PR TITLE
Allow wireguard build to gracefully exit on devices with newer kernels

### DIFF
--- a/services/wireguard/Dockerfile
+++ b/services/wireguard/Dockerfile
@@ -4,9 +4,6 @@ FROM balenalib/amd64-debian:latest-build as builder
 RUN install_packages gcc-9 libelf-dev pkg-config flex bison python
 WORKDIR /usr/src/app
 
-RUN git clone https://git.zx2c4.com/wireguard-linux-compat && \
-    git clone https://git.zx2c4.com/wireguard-tools
-
 # for raspberry pi
 # ENV VERSION '2.88.4.dev'
 # ENV BALENA_MACHINE_NAME 'raspberrypi4-64'
@@ -25,34 +22,15 @@ ENV BALENA_MACHINE_NAME 'genericx86-64-ext'
 
 RUN curl -L https://files.balena-cloud.com/images/$BALENA_MACHINE_NAME/$(echo $VERSION | sed s/+/%2B/)/kernel_modules_headers.tar.gz | tar xz
 
-# Download missing header(s) https://forums.balena.io/t/build-kernel-module-out-of-tree-for-jetson/295852/22
-# This is required on some devices like the RockPi 4B
-RUN HYPERVISOR_HEADER=kernel_modules_headers/arch/arm/include/asm/xen/hypervisor.h && \
-    if [ ! -f $HYPERVISOR_HEADER ]; then \
-        mkdir -p $(dirname $HYPERVISOR_HEADER) && \
-        curl -SsL -o $HYPERVISOR_HEADER \
-        https://raw.githubusercontent.com/OE4T/linux-tegra-4.9/oe4t-patches-l4t-r32.6/arch/arm/include/asm/xen/hypervisor.h; \
-    fi
-
-RUN ln -s /lib64/ld-linux-arm64.so.2  /lib/ld-linux-arm64.so.2 || true
-RUN ln -s /lib64/ld-linux-x86-64.so.2  /lib/ld-linux-x86-64.so.2 || true
-
-# https://github.com/Tomoms/android_kernel_oppo_msm8974/commit/11647f99b4de6bc460e106e876f72fc7af3e54a6.patch
-# RUN sed -i '/YYLTYPE/d' ./kernel_modules_headers/scripts/dtc/dtc-lexer.lex.c
-RUN echo 'CFLAGS_main.o := -Wno-missing-attributes' >> ./wireguard-linux-compat/src/KBuild
-
-RUN make -C kernel_modules_headers -j$(nproc) modules_prepare
-RUN make CC=gcc-9 -C kernel_modules_headers M=$(pwd)/wireguard-linux-compat/src -j$(nproc) || true
-RUN make -C $(pwd)/wireguard-tools/src -j$(nproc) && \
-    mkdir -p $(pwd)/tools && \
-    make -C $(pwd)/wireguard-tools/src DESTDIR=$(pwd)/tools install
+COPY build.sh .
+RUN [ "sh", "build.sh" ]
 
 FROM balenalib/amd64-debian
 
 
 WORKDIR /wireguard
-# COPY --from=builder /usr/src/app/wireguard-linux-compat/src/wireguard.ko .
-COPY --from=builder /usr/src/app/tools .
+# Copy over any build artifacts that may exist
+COPY --from=builder /usr/src/app/output .
 
 RUN install_packages kmod wget wireguard-tools dnsutils qrencode miniupnpc
 

--- a/services/wireguard/Dockerfile
+++ b/services/wireguard/Dockerfile
@@ -1,7 +1,7 @@
-FROM balenalib/amd64-debian as builder
+# Change this to armv7hf for the BeagleBone Black
+FROM balenalib/amd64-debian:latest-build as builder
 
-RUN install_packages curl gcc-9 g++-9 build-essential libelf-dev libssl-dev pkg-config git flex bison python
-RUN sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 100 --slave /usr/bin/g++ g++ /usr/bin/g++-9 --slave /usr/bin/gcov gcov /usr/bin/gcov-9
+RUN install_packages gcc-9 libelf-dev pkg-config flex bison python
 WORKDIR /usr/src/app
 
 RUN git clone https://git.zx2c4.com/wireguard-linux-compat && \
@@ -15,18 +15,24 @@ RUN git clone https://git.zx2c4.com/wireguard-linux-compat && \
 # ENV VERSION '2.83.10+rev1.dev'
 # ENV BALENA_MACHINE_NAME 'rockpi-4b-rk3399'
 
+# for beaglebone-black
+# ENV VERSION '2.85.16+rev1.dev'
+# ENV BALENA_MACHINE_NAME 'beaglebone-black'
+
 # docker
 ENV VERSION '2.83.18+rev1.dev'
 ENV BALENA_MACHINE_NAME 'genericx86-64-ext'
 
-RUN curl -L -o headers.tar.gz $(echo "https://files.balena-cloud.com/images/$BALENA_MACHINE_NAME/$VERSION/kernel_modules_headers.tar.gz" | sed -e 's/+/%2B/') && \
-    tar -xf headers.tar.gz
+RUN curl -L https://files.balena-cloud.com/images/$BALENA_MACHINE_NAME/$(echo $VERSION | sed s/+/%2B/)/kernel_modules_headers.tar.gz | tar xz
 
 # Download missing header(s) https://forums.balena.io/t/build-kernel-module-out-of-tree-for-jetson/295852/22
-RUN mkdir -p kernel_modules_headers/arch/arm/include/asm/xen && \
-    curl -SsL -o kernel_modules_headers/arch/arm/include/asm/xen/hypervisor.h \
-    https://raw.githubusercontent.com/OE4T/linux-tegra-4.9/oe4t-patches-l4t-r32.6/arch/arm/include/asm/xen/hypervisor.h
-
+# This is required on some devices like the RockPi 4B
+RUN HYPERVISOR_HEADER=kernel_modules_headers/arch/arm/include/asm/xen/hypervisor.h && \
+    if [ ! -f $HYPERVISOR_HEADER ]; then \
+        mkdir -p $(dirname $HYPERVISOR_HEADER) && \
+        curl -SsL -o $HYPERVISOR_HEADER \
+        https://raw.githubusercontent.com/OE4T/linux-tegra-4.9/oe4t-patches-l4t-r32.6/arch/arm/include/asm/xen/hypervisor.h; \
+    fi
 
 RUN ln -s /lib64/ld-linux-arm64.so.2  /lib/ld-linux-arm64.so.2 || true
 RUN ln -s /lib64/ld-linux-x86-64.so.2  /lib/ld-linux-x86-64.so.2 || true

--- a/services/wireguard/Dockerfile
+++ b/services/wireguard/Dockerfile
@@ -22,7 +22,8 @@ ENV BALENA_MACHINE_NAME 'genericx86-64-ext'
 
 RUN curl -L https://files.balena-cloud.com/images/$BALENA_MACHINE_NAME/$(echo $VERSION | sed s/+/%2B/)/kernel_modules_headers.tar.gz | tar xz
 
-COPY build.sh .
+COPY fetch.sh build.sh ./
+RUN [ "sh", "fetch.sh" ]
 RUN [ "sh", "build.sh" ]
 
 FROM balenalib/amd64-debian

--- a/services/wireguard/build.sh
+++ b/services/wireguard/build.sh
@@ -5,9 +5,6 @@ mkdir output
 KERNEL_RELEASE=$(cat kernel_modules_headers/include/config/kernel.release)
 dpkg --compare-versions $KERNEL_RELEASE ge 5.6 && exit 0
 
-git clone https://git.zx2c4.com/wireguard-linux-compat
-git clone https://git.zx2c4.com/wireguard-tools
-
 # Download missing header(s) https://forums.balena.io/t/build-kernel-module-out-of-tree-for-jetson/295852/22
 # This is required on some devices like the RockPi 4B
 HYPERVISOR_HEADER=kernel_modules_headers/arch/arm/include/asm/xen/hypervisor.h

--- a/services/wireguard/build.sh
+++ b/services/wireguard/build.sh
@@ -1,0 +1,31 @@
+set -ve
+mkdir output
+
+# Abort building wireguard for this kernel if it is already included
+KERNEL_RELEASE=$(cat kernel_modules_headers/include/config/kernel.release)
+dpkg --compare-versions $KERNEL_RELEASE ge 5.6 && exit 0
+
+git clone https://git.zx2c4.com/wireguard-linux-compat
+git clone https://git.zx2c4.com/wireguard-tools
+
+# Download missing header(s) https://forums.balena.io/t/build-kernel-module-out-of-tree-for-jetson/295852/22
+# This is required on some devices like the RockPi 4B
+HYPERVISOR_HEADER=kernel_modules_headers/arch/arm/include/asm/xen/hypervisor.h
+if [ ! -f $HYPERVISOR_HEADER ]; then
+    mkdir -p $(dirname $HYPERVISOR_HEADER)
+    curl -SsL -o $HYPERVISOR_HEADER
+    https://raw.githubusercontent.com/OE4T/linux-tegra-4.9/oe4t-patches-l4t-r32.6/arch/arm/include/asm/xen/hypervisor.h
+fi
+
+ln -s /lib64/ld-linux-arm64.so.2  /lib/ld-linux-arm64.so.2 || true
+ln -s /lib64/ld-linux-x86-64.so.2  /lib/ld-linux-x86-64.so.2 || true
+
+# https://github.com/Tomoms/android_kernel_oppo_msm8974/commit/11647f99b4de6bc460e106e876f72fc7af3e54a6.patch
+# RUN sed -i '/YYLTYPE/d' ./kernel_modules_headers/scripts/dtc/dtc-lexer.lex.c
+echo 'CFLAGS_main.o := -Wno-missing-attributes' >> ./wireguard-linux-compat/src/KBuild
+
+make CC=gcc-9 -C kernel_modules_headers M=wireguard-linux-compat/src -j$(nproc) && \
+    mv wireguard-linux-compat/src/wireguard.ko output
+make -C $(pwd)/wireguard-tools/src -j$(nproc) && \
+    mkdir -p $(pwd)/tools && \
+    make -C $(pwd)/wireguard-tools/src DESTDIR=output install

--- a/services/wireguard/fetch.sh
+++ b/services/wireguard/fetch.sh
@@ -1,0 +1,5 @@
+KERNEL_RELEASE=$(cat kernel_modules_headers/include/config/kernel.release)
+dpkg --compare-versions $KERNEL_RELEASE ge 5.6 && exit 0
+
+git clone https://git.zx2c4.com/wireguard-linux-compat
+git clone https://git.zx2c4.com/wireguard-tools


### PR DESCRIPTION
On devices with newer kernels, wireguard is already available as a module. This results in an error when building, see #6.
This patch separates out the build steps and checks the kernel version before continuing.
Tested on a BeagleBone Black (kernel ver. 5.4; without in-tree wireguard) and a generic amd64 vm (kernel ver. 5.10; with)

The fetch step had to be separated out so that it is downloaded sparingly. Source code is downloaded only when the device requires it and should persist indefinitely.