### PR TITLE
Use API to get latest dev version of balenaOS

### DIFF
--- a/services/wireguard/Dockerfile.template
+++ b/services/wireguard/Dockerfile.template
@@ -1,24 +1,10 @@
 FROM balenalib/%%BALENA_ARCH%%-debian:latest-build as builder
 
-RUN install_packages curl gcc-9 g++-9 libelf-dev pkg-config flex bison python
+RUN install_packages curl gcc-9 g++-9 libelf-dev pkg-config flex bison python jq
 WORKDIR /usr/src/app
 
-# for raspberry pi
-# ENV VERSION '2.88.4.dev'
-
-# for rockpi
-ENV VERSION '2.83.10+rev1.dev'
-
-# for beaglebone-black
-# ENV VERSION '2.85.16+rev1.dev'
-
-# docker
-# ENV VERSION '2.83.18+rev1.dev'
-
-RUN curl -L https://files.balena-cloud.com/images/%%BALENA_MACHINE_NAME%%/$(echo $VERSION | sed s/+/%2B/)/kernel_modules_headers.tar.gz | tar xz
-
 COPY fetch.sh build.sh ./
-RUN [ "sh", "fetch.sh" ]
+RUN [ "sh", "fetch.sh", "%%BALENA_MACHINE_NAME%%" ]
 RUN [ "sh", "build.sh" ]
 
 FROM balenalib/%%BALENA_ARCH%%-debian

--- a/services/wireguard/fetch.sh
+++ b/services/wireguard/fetch.sh
@@ -1,3 +1,8 @@
+VERSION=$(curl https://api.balena-cloud.com/device-types/v1/$1/images |
+	      # The latest development version, replacing + with %2B.
+	      jq -r 'first(.versions[] | select(endswith("dev"))) | sub("\\+"; "%2B")')
+curl -L https://files.balena-cloud.com/images/$1/$VERSION/kernel_modules_headers.tar.gz | tar xz
+
 KERNEL_RELEASE=$(cat kernel_modules_headers/include/config/kernel.release)
 dpkg --compare-versions $KERNEL_RELEASE ge 5.6 && exit 0
 


### PR DESCRIPTION
Use a balena API to fetch the correct version of kernel headers.
Example URL: https://api.balena-cloud.com/device-types/v1/rockpi-4b-rk3399/images

I've tested the pipeline with the current platforms supported (raspi, rockpi, bbb, docker) and the only difference was that the Raspberry Pi release would have '+rev0' added but the .txz was the same.