### PR TITLE
Fix building of yggdrasil

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,3 +5,5 @@
 [submodule "services/yggdrasil"]
 	path = services/yggdrasil
 	url = https://github.com/samizdapp/yggdrasil-go.git
+[submodule "services/yggdrasil/"]
+	branch = develop

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -276,6 +276,8 @@ services:
     build:
       context: services/yggdrasil
       dockerfile: contrib/docker/Dockerfile
+      args:
+        PKGVER: 0.1
     privileged: true
     network_mode: host
     volumes:


### PR DESCRIPTION
Yggdrasil would fail to build due to it being a submodule.
The dockerfile copies over the entire project root including `.git`. If the Yggdrasil repo was cloned as a submodule, `.git` would be a file pointing to `../../.git/modules/service/yggdrasil`. This causes the build to fail as that path isn't a git repo, as it doesn't exist in the container:

>fatal: not a git repository: /src/../../.git/modules/service/yggdrasil

A `git submodule update --remote` is required.
See also: samizdapp/yggdrasil-go@29307fe